### PR TITLE
bump dino_park_gate 0.8.1->0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,8 +863,8 @@ dependencies = [
 
 [[package]]
 name = "dino_park_gate"
-version = "0.8.1"
-source = "git+https://github.com/mozilla-iam/dino-park-gate?branch=0.8#912ccd4198753b124283543781bb81157520f730"
+version = "0.8.2"
+source = "git+https://github.com/mozilla-iam/dino-park-gate?branch=0.8.2#13e3c4052eff178720fc7589c867fba8e4332aff"
 dependencies = [
  "actix-service",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ local = ["dino_park_gate/localuserscope"]
 [dependencies]
 cis_client = { git = "https://github.com/mozilla-iam/cis_client-rust", branch = "0.7", version = "0.7" }
 cis_profile = { git = "https://github.com/mozilla-iam/cis_profile-rust", branch = "0.4", version = "0.4", features = ["aws", "vendored"] }
-dino_park_gate = { git = "https://github.com/mozilla-iam/dino-park-gate", branch = "0.8.1", version = "0.8.1" }
+dino_park_gate = { git = "https://github.com/mozilla-iam/dino-park-gate", branch = "0.8.2", version = "0.8.2" }
 dino_park_guard = { git = "https://github.com/mozilla-iam/dino-park-guard", branch = "0.3", version = "0.3" }
 dino_park_trust = { git = "https://github.com/mozilla-iam/dino-park-trust", tag = "0.0.7", version = "0.0.7" }
 diesel = { version = "1.4", features = ["postgres", "uuidv07", "r2d2", "chrono", "serde_json"] }


### PR DESCRIPTION
To deploy the issue identified in https://github.com/mozilla-iam/dino-park-gate/issues/7, we need to bump the version number here as well. The associated branch/version are prepared in the repository.