### PR TITLE
Add more information to ProfileNotFound error

### DIFF
--- a/src/db/internal/user.rs
+++ b/src/db/internal/user.rs
@@ -50,7 +50,7 @@ pub fn user_profile_by_uuid(
         .first::<UserProfileValue>(connection)
         .map_err(Error::from)
         .and_then(|p| UserProfile::try_from(p).map_err(Into::into))
-        .map_err(|_| PacksError::ProfileNotFound.into())
+        .map_err(|err| PacksError::ProfileNotFound(user_uuid.to_string(), err.to_string()).into())
 }
 
 pub fn user_profile_by_uuid_maybe(
@@ -67,7 +67,7 @@ pub fn user_profile_by_uuid_maybe(
         .optional()
         .map_err(Error::from)
         .map(|p| p.and_then(|p| UserProfile::try_from(p).ok()))
-        .map_err(|_| PacksError::ProfileNotFound.into())
+        .map_err(|err| PacksError::ProfileNotFound(user_uuid.to_string(), err.to_string()).into())
 }
 
 pub fn slim_user_profile_by_uuid(
@@ -84,7 +84,7 @@ pub fn slim_user_profile_by_uuid(
         .filter(p::user_uuid.eq(user_uuid))
         .select((p::user_uuid, p::user_id, p::email, p::username, p::trust))
         .first::<UserProfileSlim>(connection)
-        .map_err(|_| PacksError::ProfileNotFound.into())
+        .map_err(|err| PacksError::ProfileNotFound(user_uuid.to_string(), err.to_string()).into())
 }
 
 pub fn user_profile_by_user_id(
@@ -96,7 +96,7 @@ pub fn user_profile_by_user_id(
         .first::<UserProfileValue>(connection)
         .map_err(Error::from)
         .and_then(|p| UserProfile::try_from(p).map_err(Into::into))
-        .map_err(|_| PacksError::ProfileNotFound.into())
+        .map_err(|err| PacksError::ProfileNotFound(user_id.to_string(), err.to_string()).into())
 }
 
 pub fn delete_user(connection: &PgConnection, user: &User) -> Result<(), Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,12 @@
 #[derive(Fail, Debug, PartialEq)]
+
 pub enum PacksError {
     #[fail(display = "last_admin_of_group")]
     LastAdmin,
     #[fail(display = "error_deleting_members")]
     ErrorDeletingMembers,
-    #[fail(display = "profile_not_found")]
-    ProfileNotFound,
+    #[fail(display = "profile_not_found: {}. ({})", _0, _1)]
+    ProfileNotFound(String, String),
     #[fail(display = "group_name_exists")]
     GroupNameExists,
     #[fail(display = "invalid_group_data")]


### PR DESCRIPTION
When the `dino-park-packs-notify-cron` fails it returns an error of `profile_not_found`. This PR adds more information to that error so that we can better understand which profile is not found for further troubleshooting.

```
k logs dino-park-packs-notify-cron-1650974400-75nvn
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    29  100    29    0     0     11      0  0:00:02  0:00:02 --:--:--    11
{"error":"profile_not_found"}
```