### PR TITLE
Add explicit maintenance window and backups

### DIFF
--- a/terraform/prod/db.tf
+++ b/terraform/prod/db.tf
@@ -14,13 +14,13 @@ resource "aws_db_instance" "dino_park_packs_db" {
 }
 
 resource "aws_db_subnet_group" "dino_park_packs_db" {
-  name = "dino-park-packs-db-${var.environment}-${var.region}"
+  name        = "dino-park-packs-db-${var.environment}-${var.region}"
   description = "Subnet for DinoPark prod DB"
   subnet_ids  = flatten([data.terraform_remote_state.vpc.outputs.private_subnets])
 }
 
 resource "aws_security_group" "dino_park_packs_db" {
-  name = "dino-park-packs-db-${var.environment}-${var.region}"
+  name   = "dino-park-packs-db-${var.environment}-${var.region}"
   vpc_id = data.terraform_remote_state.vpc.outputs.vpc_id
 
   ingress {

--- a/terraform/prod/db.tf
+++ b/terraform/prod/db.tf
@@ -11,6 +11,14 @@ resource "aws_db_instance" "dino_park_packs_db" {
   password                    = "oneTimePassword"
   db_subnet_group_name        = aws_db_subnet_group.dino_park_packs_db.id
   vpc_security_group_ids      = [aws_security_group.dino_park_packs_db.id]
+  # Saturdays, at 3:00 AM (UTC); 7:00 PM (PST); 10:00 PM (EST) to
+  #               5:00 AM (UTC); 9:00 PM (PST); 12:00 AM (EST), respectively.
+  maintenance_window = "Sat:03:00-Sat:05:00"
+  # Backup every day at 2:00 AM (UTC); 6:00 PM (PST); 9:00 PM (EST) to
+  #                     2:59 AM (UTC); 6:69 PM (PST); 9:59 PM (EST), respectively.
+  backup_window           = "02:00-02:59"
+  backup_retention_period = "15" # days
+  copy_tags_to_snapshot   = true
 }
 
 resource "aws_db_subnet_group" "dino_park_packs_db" {

--- a/terraform/test/db.tf
+++ b/terraform/test/db.tf
@@ -12,6 +12,14 @@ resource "aws_db_instance" "dino_park_packs_db" {
   db_subnet_group_name                = aws_db_subnet_group.dino_park_packs_db.id
   vpc_security_group_ids              = [aws_security_group.dino_park_packs_db.id]
   iam_database_authentication_enabled = true
+  # Saturdays, at 3:00 AM (UTC); 7:00 PM (PST); 10:00 PM (EST) to
+  #               5:00 AM (UTC); 9:00 PM (PST); 12:00 AM (EST), respectively.
+  maintenance_window = "Sat:03:00-Sat:05:00"
+  # Backup every day at 2:00 AM (UTC); 6:00 PM (PST); 9:00 PM (EST) to
+  #                     2:59 AM (UTC); 6:69 PM (PST); 9:59 PM (EST), respectively.
+  backup_window           = "02:00-02:59"
+  backup_retention_period = "15" # days
+  copy_tags_to_snapshot   = true
 }
 
 resource "aws_db_subnet_group" "dino_park_packs_db" {

--- a/terraform/test/db.tf
+++ b/terraform/test/db.tf
@@ -11,6 +11,7 @@ resource "aws_db_instance" "dino_park_packs_db" {
   password                            = "oneTimePassword"
   db_subnet_group_name                = aws_db_subnet_group.dino_park_packs_db.id
   vpc_security_group_ids              = [aws_security_group.dino_park_packs_db.id]
+  iam_database_authentication_enabled = true
 }
 
 resource "aws_db_subnet_group" "dino_park_packs_db" {

--- a/terraform/test/db.tf
+++ b/terraform/test/db.tf
@@ -1,26 +1,26 @@
 resource "aws_db_instance" "dino_park_packs_db" {
-  identifier                  = "dino-park-packs-db-${var.environment}-${var.region}"
-  allocated_storage           = 10
-  max_allocated_storage       = 100
-  storage_type                = "gp2"
-  engine                      = "postgres"
-  engine_version              = "11"
-  instance_class              = "db.t3.micro"
-  allow_major_version_upgrade = true
-  username                    = "dinopark"
-  password                    = "oneTimePassword"
-  db_subnet_group_name        = aws_db_subnet_group.dino_park_packs_db.id
-  vpc_security_group_ids      = [aws_security_group.dino_park_packs_db.id]
+  identifier                          = "dino-park-packs-db-${var.environment}-${var.region}"
+  allocated_storage                   = 10
+  max_allocated_storage               = 100
+  storage_type                        = "gp2"
+  engine                              = "postgres"
+  engine_version                      = "11"
+  instance_class                      = "db.t3.micro"
+  allow_major_version_upgrade         = true
+  username                            = "dinopark"
+  password                            = "oneTimePassword"
+  db_subnet_group_name                = aws_db_subnet_group.dino_park_packs_db.id
+  vpc_security_group_ids              = [aws_security_group.dino_park_packs_db.id]
 }
 
 resource "aws_db_subnet_group" "dino_park_packs_db" {
-  name = "dino-park-packs-db-${var.environment}-${var.region}"
+  name        = "dino-park-packs-db-${var.environment}-${var.region}"
   description = "Subnet for DinoPark test DB"
   subnet_ids  = flatten([data.terraform_remote_state.vpc.outputs.private_subnets])
 }
 
 resource "aws_security_group" "dino_park_packs_db" {
-  name = "dino-park-packs-db-${var.environment}-${var.region}"
+  name   = "dino-park-packs-db-${var.environment}-${var.region}"
   vpc_id = data.terraform_remote_state.vpc.outputs.vpc_id
 
   ingress {


### PR DESCRIPTION
Jira: [IAM-1502](https://mozilla-hub.atlassian.net/browse/IAM-1502)

---

<details>
<summary>Terraform plan for <code>terraform/test</code></summary>

```
Terraform will perform the following actions:

  # aws_db_instance.dino_park_packs_db will be updated in-place
  ~ resource "aws_db_instance" "dino_park_packs_db" {
        address                               = "dino-park-packs-db-test-us-west-2.ct1yzfxfuap7.us-west-2.rds.amazonaws.com"
        allocated_storage                     = 10
        allow_major_version_upgrade           = true
        arn                                   = "arn:aws:rds:us-west-2:320464205386:db:dino-park-packs-db-test-us-west-2"
        auto_minor_version_upgrade            = true
        availability_zone                     = "us-west-2a"
      ~ backup_retention_period               = 0 -> 15
      ~ backup_window                         = "08:06-08:36" -> "02:00-02:59"
        ca_cert_identifier                    = "rds-ca-rsa2048-g1"
      ~ copy_tags_to_snapshot                 = false -> true
        db_subnet_group_name                  = "dino-park-packs-db-test-us-west-2"
        delete_automated_backups              = true
        deletion_protection                   = false
        enabled_cloudwatch_logs_exports       = []
        endpoint                              = "dino-park-packs-db-test-us-west-2.ct1yzfxfuap7.us-west-2.rds.amazonaws.com:5432"
        engine                                = "postgres"
        engine_version                        = "11.22"
        hosted_zone_id                        = "Z1PVIF0B656C1W"
        iam_database_authentication_enabled   = true
        id                                    = "dino-park-packs-db-test-us-west-2"
        identifier                            = "dino-park-packs-db-test-us-west-2"
        instance_class                        = "db.t3.micro"
        iops                                  = 0
        license_model                         = "postgresql-license"
      ~ maintenance_window                    = "sun:10:22-sun:10:52" -> "sat:03:00-sat:05:00"
        max_allocated_storage                 = 100
        monitoring_interval                   = 0
        multi_az                              = false
        option_group_name                     = "default:postgres-11"
        parameter_group_name                  = "default.postgres11"
        password                              = (sensitive value)
        performance_insights_enabled          = false
        performance_insights_retention_period = 0
        port                                  = 5432
        publicly_accessible                   = false
        replicas                              = []
        resource_id                           = "db-643FGGRBLGIEMCH53HFF22CZFI"
        security_group_names                  = []
        skip_final_snapshot                   = false
        status                                = "available"
        storage_encrypted                     = false
        storage_type                          = "gp2"
        tags                                  = {}
        username                              = "dinopark"
        vpc_security_group_ids                = [
            "sg-034ab563c9e967ace",
        ]
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```
</details>

<details>
<summary>Terraform plan for <code>terraform/prod</code></summary>

```
Terraform will perform the following actions:

  # aws_db_instance.dino_park_packs_db will be updated in-place
  ~ resource "aws_db_instance" "dino_park_packs_db" {
        address                               = "dino-park-packs-db-prod-us-west-2.ct1yzfxfuap7.us-west-2.rds.amazonaws.com"
        allocated_storage                     = 10
        allow_major_version_upgrade           = true
        arn                                   = "arn:aws:rds:us-west-2:320464205386:db:dino-park-packs-db-prod-us-west-2"
        auto_minor_version_upgrade            = true
        availability_zone                     = "us-west-2a"
      ~ backup_retention_period               = 0 -> 15
      ~ backup_window                         = "09:01-09:31" -> "02:00-02:59"
        ca_cert_identifier                    = "rds-ca-rsa2048-g1"
      ~ copy_tags_to_snapshot                 = false -> true
        db_subnet_group_name                  = "dino-park-packs-db-prod-us-west-2"
        delete_automated_backups              = true
        deletion_protection                   = false
        enabled_cloudwatch_logs_exports       = []
        endpoint                              = "dino-park-packs-db-prod-us-west-2.ct1yzfxfuap7.us-west-2.rds.amazonaws.com:5432"
        engine                                = "postgres"
        engine_version                        = "11.22"
        hosted_zone_id                        = "Z1PVIF0B656C1W"
        iam_database_authentication_enabled   = false
        id                                    = "dino-park-packs-db-prod-us-west-2"
        identifier                            = "dino-park-packs-db-prod-us-west-2"
        instance_class                        = "db.t3.micro"
        iops                                  = 0
        license_model                         = "postgresql-license"
      ~ maintenance_window                    = "fri:07:12-fri:07:42" -> "sat:03:00-sat:05:00"
        max_allocated_storage                 = 100
        monitoring_interval                   = 0
        multi_az                              = false
        option_group_name                     = "default:postgres-11"
        parameter_group_name                  = "default.postgres11"
        password                              = (sensitive value)
        performance_insights_enabled          = false
        performance_insights_retention_period = 0
        port                                  = 5432
        publicly_accessible                   = false
        replicas                              = []
        resource_id                           = "db-6XZIG34MX2IV73QMVNNH4G4U3U"
        security_group_names                  = []
        skip_final_snapshot                   = false
        status                                = "available"
        storage_encrypted                     = false
        storage_type                          = "gp2"
        tags                                  = {}
        username                              = "dinopark"
        vpc_security_group_ids                = [
            "sg-02b750ace18018caa",
        ]
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
</details>