### PR TITLE
chore Upgrade to Postgres 16.1 (test+prod)

### DIFF
--- a/terraform/prod/db.tf
+++ b/terraform/prod/db.tf
@@ -21,17 +21,17 @@ resource "aws_db_instance" "dino_park_packs_db" {
   copy_tags_to_snapshot   = true
 }
 
-resource "aws_db_instance" "dino_park_packs_db_16_2" {
-  identifier                  = "dino-park-packs-db-${var.environment}-${var.region}-16-2"
+resource "aws_db_instance" "dino_park_packs_db_green" {
+  identifier                  = "dino-park-packs-db-${var.environment}-${var.region}-green"
   allocated_storage           = 10
   max_allocated_storage       = 100
   storage_type                = "gp2"
   engine                      = "postgres"
-  engine_version              = "16.2"
+  engine_version              = "16.1"
   instance_class              = "db.t3.micro"
   allow_major_version_upgrade = true
   username                    = "dinopark"
-  snapshot_identifier         = "rds:dino-park-packs-db-prod-us-west-2-2024-12-13-02-07"
+  snapshot_identifier         = "dino-park-packs-db-prod-us-west-2-2025-01-14-iam-1502"
   db_subnet_group_name        = aws_db_subnet_group.dino_park_packs_db.id
   vpc_security_group_ids      = [aws_security_group.dino_park_packs_db.id]
   # Saturdays, at 3:00 AM (UTC); 7:00 PM (PST); 10:00 PM (EST) to

--- a/terraform/prod/db.tf
+++ b/terraform/prod/db.tf
@@ -4,11 +4,34 @@ resource "aws_db_instance" "dino_park_packs_db" {
   max_allocated_storage       = 100
   storage_type                = "gp2"
   engine                      = "postgres"
-  engine_version              = "16.1"
+  engine_version              = "11.22"
   instance_class              = "db.t3.micro"
   allow_major_version_upgrade = true
   username                    = "dinopark"
   password                    = "oneTimePassword"
+  db_subnet_group_name        = aws_db_subnet_group.dino_park_packs_db.id
+  vpc_security_group_ids      = [aws_security_group.dino_park_packs_db.id]
+  # Saturdays, at 3:00 AM (UTC); 7:00 PM (PST); 10:00 PM (EST) to
+  #               5:00 AM (UTC); 9:00 PM (PST); 12:00 AM (EST), respectively.
+  maintenance_window = "Sat:03:00-Sat:05:00"
+  # Backup every day at 2:00 AM (UTC); 6:00 PM (PST); 9:00 PM (EST) to
+  #                     2:59 AM (UTC); 6:69 PM (PST); 9:59 PM (EST), respectively.
+  backup_window           = "02:00-02:59"
+  backup_retention_period = "15" # days
+  copy_tags_to_snapshot   = true
+}
+
+resource "aws_db_instance" "dino_park_packs_db_16_2" {
+  identifier                  = "dino-park-packs-db-${var.environment}-${var.region}-16-2"
+  allocated_storage           = 10
+  max_allocated_storage       = 100
+  storage_type                = "gp2"
+  engine                      = "postgres"
+  engine_version              = "16.2"
+  instance_class              = "db.t3.micro"
+  allow_major_version_upgrade = true
+  username                    = "dinopark"
+  snapshot_identifier         = "rds:dino-park-packs-db-prod-us-west-2-2024-12-13-02-07"
   db_subnet_group_name        = aws_db_subnet_group.dino_park_packs_db.id
   vpc_security_group_ids      = [aws_security_group.dino_park_packs_db.id]
   # Saturdays, at 3:00 AM (UTC); 7:00 PM (PST); 10:00 PM (EST) to

--- a/terraform/prod/db.tf
+++ b/terraform/prod/db.tf
@@ -4,7 +4,7 @@ resource "aws_db_instance" "dino_park_packs_db" {
   max_allocated_storage       = 100
   storage_type                = "gp2"
   engine                      = "postgres"
-  engine_version              = "11.22"
+  engine_version              = "16.1"
   instance_class              = "db.t3.micro"
   allow_major_version_upgrade = true
   username                    = "dinopark"

--- a/terraform/test/db.tf
+++ b/terraform/test/db.tf
@@ -4,7 +4,7 @@ resource "aws_db_instance" "dino_park_packs_db" {
   max_allocated_storage               = 100
   storage_type                        = "gp2"
   engine                              = "postgres"
-  engine_version                      = "11.22"
+  engine_version                      = "16.1"
   instance_class                      = "db.t3.micro"
   allow_major_version_upgrade         = true
   username                            = "dinopark"


### PR DESCRIPTION
chore Upgrade to Postgres 16.1 (test+prod)

Dev is already ahead of the game by being on 16.2:

```
; kubectl --context iam-dev exec -it dino-park-packs-pg-deployment-56b7dd5b49-gd688 -- postgres --version
postgres (PostgreSQL) 16.2 (Debian 16.2-1.pgdg120+2)
```

@gcoxmoz pointed out 

    pg_upgrade supports upgrades from 9.2.X and later to the current major release of PostgreSQL, including snapshot and beta releases.

See: https://www.postgresql.org/docs/16/pgupgrade.html

Jira: [IAM-1502](https://mozilla-hub.atlassian.net/browse/IAM-1502)

---

<details>
<summary>Terraform plan for <code>test</code>

```
Terraform will perform the following actions:

  # aws_db_instance.dino_park_packs_db will be updated in-place
  ~ resource "aws_db_instance" "dino_park_packs_db" {
      + apply_immediately                     = false
      ~ engine_version                        = "11.22" -> "16.1"
        id                                    = "db-643FGGRBLGIEMCH53HFF22CZFI"
        tags                                  = {}
        # (69 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
</details>

<details>
<summary>Terraform plan for <code>prod</code>

```
  # aws_db_instance.dino_park_packs_db_16_2 will be created
  + resource "aws_db_instance" "dino_park_packs_db_16_2" {
      + address                               = (known after apply)
      + allocated_storage                     = 10
      + allow_major_version_upgrade           = true
      + apply_immediately                     = false
      + arn                                   = (known after apply)
      + auto_minor_version_upgrade            = true
      + availability_zone                     = (known after apply)
      + backup_retention_period               = 15
      + backup_target                         = (known after apply)
      + backup_window                         = "02:00-02:59"
      + ca_cert_identifier                    = (known after apply)
      + character_set_name                    = (known after apply)
      + copy_tags_to_snapshot                 = true
      + db_name                               = (known after apply)
      + db_subnet_group_name                  = "dino-park-packs-db-prod-us-west-2"
      + dedicated_log_volume                  = false
      + delete_automated_backups              = true
      + domain_fqdn                           = (known after apply)
      + endpoint                              = (known after apply)
      + engine                                = "postgres"
      + engine_lifecycle_support              = (known after apply)
      + engine_version                        = "16.2"
      + engine_version_actual                 = (known after apply)
      + hosted_zone_id                        = (known after apply)
      + id                                    = (known after apply)
      + identifier                            = "dino-park-packs-db-prod-us-west-2-16-2"
      + identifier_prefix                     = (known after apply)
      + instance_class                        = "db.t3.micro"
      + iops                                  = (known after apply)
      + kms_key_id                            = (known after apply)
      + latest_restorable_time                = (known after apply)
      + license_model                         = (known after apply)
      + listener_endpoint                     = (known after apply)
      + maintenance_window                    = "sat:03:00-sat:05:00"
      + master_user_secret                    = (known after apply)
      + master_user_secret_kms_key_id         = (known after apply)
      + max_allocated_storage                 = 100
      + monitoring_interval                   = 0
      + monitoring_role_arn                   = (known after apply)
      + multi_az                              = (known after apply)
      + nchar_character_set_name              = (known after apply)
      + network_type                          = (known after apply)
      + option_group_name                     = (known after apply)
      + parameter_group_name                  = (known after apply)
      + performance_insights_enabled          = false
      + performance_insights_kms_key_id       = (known after apply)
      + performance_insights_retention_period = (known after apply)
      + port                                  = (known after apply)
      + publicly_accessible                   = false
      + replica_mode                          = (known after apply)
      + replicas                              = (known after apply)
      + resource_id                           = (known after apply)
      + skip_final_snapshot                   = false
      + snapshot_identifier                   = "rds:dino-park-packs-db-prod-us-west-2-2024-12-13-02-07"
      + status                                = (known after apply)
      + storage_throughput                    = (known after apply)
      + storage_type                          = "gp2"
      + tags_all                              = (known after apply)
      + timezone                              = (known after apply)
      + username                              = "dinopark"
      + vpc_security_group_ids                = [
          + "sg-02b750ace18018caa",
        ]
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
</details>